### PR TITLE
handle unary expressions

### DIFF
--- a/lib/alce.js
+++ b/lib/alce.js
@@ -32,6 +32,8 @@ exports.parse = function(src, options) {
         stack.unshift(new AST.Property(node, src, options));
       } else if (node.type === 'Identifier' || node.type === 'Literal') {
         stack.unshift(new AST.Value(node, src, options));
+      } else if (node.type === 'UnaryExpression' && (node.operator === '-' || node.operator === '+')) {
+        stack.unshift(new AST.Value(node, src, options));
       } else if (node.type === 'Program') {
         node.ignore = true;
       } else {

--- a/lib/ast/value.js
+++ b/lib/ast/value.js
@@ -13,7 +13,15 @@ function Value(node, src, options) {
   this.range = node.range;
   this.source = extractRange(src, node.range);
 
-  this.value = node.name || node.value;
+  if (node.type === 'UnaryExpression') {
+    if (node.operator === '-') {
+      this.value = -1 * node.argument.value;
+    } else if (node.operator === '+') {
+      this.value = 1 * node.argument.value;
+    }
+  } else {
+    this.value = node.name || node.value;
+  }
 }
 Value.prototype = {
   preamble: '',

--- a/test/alce.js
+++ b/test/alce.js
@@ -85,7 +85,7 @@ describe('ALCE', function () {
           bar: {}
         },
 
-        arrays: [ 'foo', 9, {bar: true}, [{nested: true}]],
+        arrays: [ 'foo', 9, -9, 9, {bar: true}, [{nested: true}]],
 
         expression: ({foo : true}),
         "other stuff": true

--- a/test/artifacts/lumbar.json
+++ b/test/artifacts/lumbar.json
@@ -13,6 +13,8 @@
   arrays: [
     'foo',
     9,
+    -9,
+    +9,
     {bar: true},
     [{
       nested: true


### PR DESCRIPTION
Previously nodes with a type of `UnaryExpression` weren't being handled and would throw an error for an unexpected node type.

This PR handles the unary negation and unary plus operators as `ast.Value` types and assigns the values by multiplying by `1` or `-1`.
